### PR TITLE
Upload library dll as artifact

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,6 +25,6 @@ jobs:
     - name: Upload library binary
       uses: actions/upload-artifact@v2
       with:
-        name: Geometry-${{ github.sha }}.dll
+        name: Geometry.dll
         path: ./Geometry/bin/Release/net5.0/Geometry.dll
       if: success()


### PR DESCRIPTION
If all tests pass in the CI pipeline, the library binary should be uploaded as an artifact. We use the release version of the dll.