### PR TITLE
Split pre-release into multiple jobs

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,7 +6,8 @@ on:
     - main
 
 jobs:
-  pre-release:
+
+  Build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -19,8 +20,43 @@ jobs:
       run: dotnet restore
     - name: Build projects
       run: dotnet build --configuration Release --no-restore
+    - name: Upload test artifacts
+      uses: actions/upload-artfact@v2.2.3
+      with:
+        name: test_artifacts
+        path: Geometry.Tests/bin/Release/net5.0
+    - name: Upload release artifacts
+      uses: actions/upload-artifact@v2.2.3
+      with:
+        name: release_artifacts
+        path: Geometry/bin/Release/net5.0/Geometry.dll
+
+  Test:
+    needs: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@1.8.0
+      with:
+        dotnet-version: 5.0.x
+    - name: Download test artifacts
+      uses: actions/download-artifact@2.0.9
+      with:
+        name: test_artifacts
+        path: ./test_artifacts
     - name: Run tests
-      run: dotnet test --configuration Release --no-build
+      working-directory: ./test_artifacts
+      run: dotnet test Geometry.Tests.dll
+
+  Pre-release:
+    needs: Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download artifacts
+      uses: actions/download_artifact@v2.0.9
+      with:
+        name: release_artifact
+        path: ./release_artifacts
     - name: Generate pre-release
       uses: marvinpinto/action-automatic-releases@v1.2.0
       with:
@@ -29,5 +65,5 @@ jobs:
         prerelease: true
         title: Development Build
         files:
-          Geometry/bin/Release/net5.0/Geometry.dll
+          ./release_artifacts/Geometry.dll
           


### PR DESCRIPTION
Use seperate build, test, and pre-release jobs and run them sequentially.